### PR TITLE
Add frequency, name and callsign filter

### DIFF
--- a/src/app/map/frqmap.component.html
+++ b/src/app/map/frqmap.component.html
@@ -18,6 +18,12 @@
               </ng-container>
             </option>
           </select>
+          <label for="frequency_filter" class="uk-margin-small-right uk-margin-small-left" i18n="@@frequency">Frequency: </label>
+          <input type="text" class="uk-input uk-width-auto" id="frequency_filter" name="frequency_filter"
+                 [(ngModel)]="filterFrequency" (ngModelChange)="loadSites()">
+          <label for="name_filter" class="uk-margin-small-right uk-margin-small-left" i18n="@@name">Name or call sign: </label>
+          <input type="text" class="uk-input uk-width-auto" id="name_filter" name="name_filter"
+                [(ngModel)]="filterName" (ngModelChange)="loadSites()">
         </p>
 
       </form>

--- a/src/app/map/frqmap.component.ts
+++ b/src/app/map/frqmap.component.ts
@@ -294,7 +294,7 @@ export class FrqmapComponent implements OnInit {
       .subscribe((response: Site[]) => {
         var filteredSites = this.trxInfoDump?.filter((trx) => {
           var search_term_freq = (this.filterFrequency ?? "").replaceAll(/[^0-9]/g, '');
-          var haystack_freq = (trx.frequency_rx + " " + trx.frequency_tx).replaceAll(/[^0-9]/g, '');
+          var haystack_freq = (trx.frequency_rx*1000 + " " + trx.frequency_tx*1000).replaceAll(/[^0-9]/g, '');
 
           var search_term_name = (this.filterName ?? "").toLowerCase();
           var haystack_name = (trx.callsign + " " + trx.site_name).toLowerCase();

--- a/src/app/scss/app.scss
+++ b/src/app/scss/app.scss
@@ -1199,7 +1199,7 @@ li {
   .uk-textarea {
     color: $black;
     font-size: 12px;
-    border-radius: 9px;
+    /*border-radius: 9px;*/ 
     border: 1px solid #9d9d9d;
     padding: 15px 10px;
 

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -79,6 +79,20 @@
           <context context-type="linenumber">39,40</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="frequency" datatype="html">
+        <source>Frequenz: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/map/frqmap.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="name" datatype="html">
+        <source>Name oder Rufzeichen: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/map/frqmap.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="introtext" datatype="html">
         <source>Willkommen auf der Repeaterseite des ÖVSV</source>
         <context-group purpose="location">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -79,6 +79,20 @@
           <context context-type="linenumber">39,40</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="frequency" datatype="html">
+        <source>Frequency: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/map/frqmap.component.html</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="name" datatype="html">
+        <source>Name or call sign: </source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/map/frqmap.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="introtext" datatype="html">
         <source>Welcome to the repeater page of the ÖVSV VHF management</source>
         <context-group purpose="location">


### PR DESCRIPTION
Added the possibility to filter the repeater map by frequency (RX/TX), site name and call sign.

For better user experience, the name/call sign filter is case insensitive. 
For frequency filtering, it will match, if the frequency info contains the search query as a substring (only minding digits, so . or , etc. are omitted)